### PR TITLE
Update train.py to avoid attribute errors

### DIFF
--- a/src/train.py
+++ b/src/train.py
@@ -104,7 +104,7 @@ def run_episode(env, policy, scaler, animate=False):
         actions.append(action)
         obs, reward, done, _ = env.step(np.squeeze(action, axis=0))
         if not isinstance(reward, float):
-            reward = np.asscalar(reward)
+            reward = np.asscalar(np.asarray(reward))
         rewards.append(reward)
         step += 1e-3  # increment time step feature
 


### PR DESCRIPTION
As explained in detail in a [numpy issue](https://github.com/numpy/numpy/issues/4701), `np.asscalar` doesn't pass through scalars. This is because it looks for `item()` method that `int` and `float` don't have. A possible workaround suggest there is the one I proposed to you. In this way your script doesn't fail with other environments such as `LunarLanderContinuous-v2`.